### PR TITLE
feat: Toggle automatic syntax highlighting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Kind of a _copy_; highly inspired from
 [Piterden/syntax-highlighter-bot](https://github.com/Piterden/syntax-highlighter-bot) -
 Telegram Bot [here](https://telegram.me/cris_highlight_bot)
 
-Minimal syntax highlighting bot for Telegram. Use it private chat or add to
+Minimal syntax highlighting bot for Telegram. Use it in private chats or add to
 group chats. Send text inside three backticks, or any message containing `pre`
 or multiline `code` entities, and the bot will reply you with syntax highlighted
 images of that piece of code. Useful in Development groups.
@@ -63,7 +63,8 @@ Thanks to these tools and libraries.
   be a <samp>pre</samp> entity formatted code block, or a multiline
   <samp>code</samp> entity.
 
-- 🖌️ · **Forced highlighting**: Replying <ins><samp>/highlight</samp></ins> or
+- <span id="forced-highlighting">🖌️ · **Forced highlighting**</span>: Replying
+  <ins><samp>/highlight</samp></ins> or
   <ins><samp>/hl</samp></ins> to a message containing text or caption, will
   - check for `pre` and `code` (multiline) entities and if there is any, only
     highlights those as it normally do. Useful if the original message was
@@ -101,8 +102,17 @@ Thanks to these tools and libraries.
     - `/hl 1 3` will highlight both `<code (inline)>` and `<pre>`.
     - `/hl 0` or `/hl f` or `/hl full` will highlight the whole message.
 
-    <!-- > **NOTE**: `/hl 0 1` only highlights the full message; not both full
-    > message and 1st `pre`/`code` entity. -->
+    **NOTE**: `/hl 0 1` only highlights the full message; not both full message
+    and 1st `pre`/`code` entity.
+
+- You can **Disable auto syntax highlighting** by using the
+  <ins><samp>/toggle_auto_hl</samp></ins> command. (Use the same command to
+  re-enable it). You don't always need the bot to highlight even the small
+  codeblocks. So, when you need the highlighting, you can force it to highlight
+  the message/code blocks. Checkout the
+  ["Forced Highlighting"](#forced-highlighting) feature.
+
+  <kbd>v0.3.0</kbd> • See [gmy#57178](https://t.me/grammyjs/57178).
 
 - Not a very useful feature; use <ins><samp>/stats</samp></ins> command to find
   how many times the bot has sent syntax highlighted images for you.
@@ -117,6 +127,8 @@ Thanks to these tools and libraries.
       backticks instead of one backtick, even for a single monospace word.
 - [ ] <b>Automatically toggle "Send as Document" _mode_</b> if there is more
       than <samp>x</samp> number of characters.
+- [ ] <b>No puppeteer.</b> Highlighting without using puppeteer. (The most
+      wanted feature).
 
 ## Setup
 

--- a/locales/en.ftl
+++ b/locales/en.ftl
@@ -1,7 +1,7 @@
 start = 
-  Hi! I can highlight multiline source code (text inside three backticks) in chats. You can set custom /font and /theme if you want to. If you want the images /as_document, you can toggle it using /as_doc.
+  Hi! I can highlight multiline source code (text inside three backticks) in chats. You can set custom /font and /theme if you want to. If you want the images /as_document, you can toggle it using /as_doc. You can also disable my default auto highlighting feature using /toggle_auto_hl.
 
-  Developed by @dcdunkan from @dcbots. See the GitHub repository <a href="https://github.com/dcdunkan/syntax-highlighter-bot">here</a>.
+  Developed by @dcdunkan from @dcbots. Read the instructions on using this bot in the GitHub repository: https://github.com/dcdunkan/syntax-highlighter-bot
   
 font =
   .info =
@@ -33,6 +33,10 @@ theme =
 as-doc =
   .enabled = No more blurry pictures! From now on, I will send images as documents!
   .disabled = Okay, from now on, I <b>won't</b> be sending images as documents!
+
+auto-highlighting =
+  .enabled = I will highlight code blocks automatically from now on!
+  .disabled = Disabled auto syntax highlighting. You can use the /hl command to force highlight a message. Read the <b>Forced Highlighting</b> section to know more about optional arguments: https://github.com/dcdunkan/syntax-highlighter-bot#readme.
 
 stats = 
   {

--- a/src/bot/bot.ts
+++ b/src/bot/bot.ts
@@ -5,12 +5,17 @@ import { fluent } from "./helpers/fluent.ts";
 import { Bot, GrammyError, HttpError, session, useFluent } from "../deps.ts";
 import { handlers } from "./handlers/mod.ts";
 import { commands, groupAdminCommands } from "./helpers/constants.ts";
+
 export const bot = new Bot<Context>(env.BOT_TOKEN);
 
 bot.use(session({ initial, storage }));
 
 bot.api.config.use((prev, method, payload) =>
-  prev(method, { parse_mode: "HTML", ...payload })
+  prev(method, {
+    ...payload,
+    parse_mode: "HTML",
+    disable_web_page_preview: true,
+  })
 );
 
 bot.use(useFluent({ fluent }));

--- a/src/bot/handlers/auto_hl.ts
+++ b/src/bot/handlers/auto_hl.ts
@@ -1,0 +1,14 @@
+import { Composer } from "../../deps.ts";
+import { Context } from "../helpers/context.ts";
+
+export const autoHighlight = new Composer<Context>();
+
+autoHighlight.command(
+  ["noautohl", "toggle_auto_hl"],
+  async (ctx) => {
+    ctx.session.auto_highlighting = !ctx.session.auto_highlighting;
+    await ctx.reply(
+      ctx.t(`auto-highlighting.${ctx.session.auto_highlighting ? "enabled" : "disabled"}`),
+    );
+  },
+);

--- a/src/bot/handlers/mod.ts
+++ b/src/bot/handlers/mod.ts
@@ -9,6 +9,7 @@ import { remove } from "./remove.ts";
 import { preCode } from "./pre_code.ts";
 import { asDocument } from "./as_doc.ts";
 import { highlight } from "./highlight.ts";
+import { autoHighlight } from "./auto_hl.ts";
 
 export const handlers = new Composer<Context>();
 
@@ -25,7 +26,8 @@ handlers
   .use(font)
   .use(theme)
   .use(asDocument)
-  .use(stats);
+  .use(stats)
+  .use(autoHighlight);
 
 handlers.on("callback_query").use(remove);
 handlers.use(preCode);

--- a/src/bot/handlers/pre_code.ts
+++ b/src/bot/handlers/pre_code.ts
@@ -5,28 +5,36 @@ import { sendImages } from "../helpers/send_images.ts";
 
 export const preCode = new Composer<Context>();
 
-preCode.on(["msg::code", "msg::pre"], async (ctx) => {
-  let text: string;
-  if (ctx.msg.text) text = ctx.msg.text;
-  else if (ctx.msg.caption) text = ctx.msg.caption;
-  else return;
+preCode.filter((ctx) => {
+  // For backward compatibility:
+  if (ctx.session.auto_highlighting === undefined) {
+    ctx.session.auto_highlighting = true;
+    return true;
+  }
+  return ctx.session.auto_highlighting;
+})
+  .on(["msg::code", "msg::pre"], async (ctx) => {
+    let text: string;
+    if (ctx.msg.text) text = ctx.msg.text;
+    else if (ctx.msg.caption) text = ctx.msg.caption;
+    else return;
 
-  let entities: MessageEntity[];
-  if (ctx.msg.entities) entities = ctx.msg.entities;
-  else if (ctx.msg.caption_entities) entities = ctx.msg.caption_entities;
-  else return;
+    let entities: MessageEntity[];
+    if (ctx.msg.entities) entities = ctx.msg.entities;
+    else if (ctx.msg.caption_entities) entities = ctx.msg.caption_entities;
+    else return;
 
-  const codeEntities = entities.filter((entity) => {
-    if (entity.type === "pre") return true;
-    if (entity.type !== "code") return;
-    // If it's the only code entity. Finally, a solution for
-    // @darvesh's test snippet: `console.log("grammY");`
-    if (entity.offset === 0 && entity.length === text.length) return true;
-    const code = text.slice(entity.offset, entity.offset + entity.length);
-    return code.trim().includes("\n");
+    const codeEntities = entities.filter((entity) => {
+      if (entity.type === "pre") return true;
+      if (entity.type !== "code") return;
+      // If it's the only code entity. Finally, a solution for
+      // @darvesh's test snippet: `console.log("grammY");`
+      if (entity.offset === 0 && entity.length === text.length) return true;
+      const code = text.slice(entity.offset, entity.offset + entity.length);
+      return code.trim().includes("\n");
+    });
+
+    if (!codeEntities.length) return;
+
+    await sendImages(ctx, text, codeEntities);
   });
-
-  if (!codeEntities.length) return;
-
-  await sendImages(ctx, text, codeEntities);
-});

--- a/src/bot/helpers/constants.ts
+++ b/src/bot/helpers/constants.ts
@@ -1,10 +1,11 @@
-export const VERSION = [0, 2, 0];
+export const VERSION = [0, 3, 0];
 
 export const groupAdminCommands = [
   { command: "theme", description: "Change color theme" },
   { command: "font", description: "Change font" },
   { command: "as_doc", description: "Toggle 'Send as document'" },
   { command: "stats", description: "Chat Stats" },
+  { command: "toggle_auto_hl", description: "Toggle automatic highlighting" },
 ];
 
 export const commands = [

--- a/src/bot/helpers/session.ts
+++ b/src/bot/helpers/session.ts
@@ -6,6 +6,7 @@ export interface SessionData {
   theme: string;
   as_document: boolean;
   count: number;
+  auto_highlighting: boolean;
 }
 
 export function initial(): SessionData {
@@ -14,6 +15,7 @@ export function initial(): SessionData {
     theme: "atom-one-dark",
     as_document: false,
     count: 0,
+    auto_highlighting: false,
   };
 }
 

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -7,7 +7,7 @@ export * as css from "https://deno.land/x/css@0.3.0/mod.ts";
 
 // src/bot
 export { cleanEnv, str } from "https://deno.land/x/envalid@v0.0.3/mod.ts";
-export { config } from "https://deno.land/std@0.135.0/dotenv/mod.ts";
+export { config } from "https://deno.land/std@0.143.0/dotenv/mod.ts";
 export {
   Bot,
   Composer,
@@ -19,18 +19,18 @@ export {
   session,
   type SessionFlavor,
   webhookCallback,
-} from "https://deno.land/x/grammy@v1.7.3/mod.ts";
+} from "https://deno.land/x/grammy@v1.8.3/mod.ts";
 export {
   type InputFileProxy,
   type Message,
   type MessageEntity,
-} from "https://cdn.skypack.dev/@grammyjs/types@v2.6.0?dts";
-export { DetaAdapter } from "https://deno.land/x/grammy_storage_deta@v1.0.2/mod.ts";
+} from "https://esm.sh/@grammyjs/types@2.7.1";
+export { DetaAdapter } from "https://deno.land/x/grammy_storages@v2.0.0/deta/src/mod.ts";
 
 export { Fluent } from "https://deno.land/x/better_fluent@v0.1.0/mod.ts";
 export {
   type FluentContextFlavor,
   useFluent,
 } from "https://raw.githubusercontent.com/dcdunkan/grammy-fluent/main/src/mod.ts";
-export { prettyBytes as bytes } from "https://deno.land/std@0.135.0/fmt/bytes.ts";
-export { serve } from "https://deno.land/std@0.135.0/http/server.ts";
+export { prettyBytes as bytes } from "https://deno.land/std@0.143.0/fmt/bytes.ts";
+export { serve } from "https://deno.land/std@0.143.0/http/server.ts";


### PR DESCRIPTION
Enable/disable automatic highlighting using the /toggle_auto_hl command. You can still force the bot to highlight something by replying /hl to a message.